### PR TITLE
Fix Starlette Host header bypass (RHOAIENG-64864)

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -29,6 +29,9 @@ COPY caikit.yml /caikit/config/caikit.yml
 ENV VIRTUAL_ENV=/caikit/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+RUN /caikit/.venv/bin/pip install --no-cache-dir \
+    "fastapi>=0.134.0" "starlette>=1.0.1" "aiohttp>=3.13.3,<4.0.0"
+
 RUN groupadd --system caikit --gid 1001 && \
     adduser --system --uid 1001 --gid 0 --groups caikit \
     --create-home --home-dir /caikit --shell /sbin/nologin \


### PR DESCRIPTION
Upgrade starlette to >=1.0.1 and fastapi to >=0.134.0 to fix the Host header security restriction bypass vulnerability ([RHOAIENG-64864](https://redhat.atlassian.net/browse/RHOAIENG-64864)).

Prior to starlette 1.0.1, a malformed HTTP Host header could cause request.url.path to differ from the actual requested path, allowing middleware and endpoint security checks based on request.url to be bypassed.fastapi was pinned to ==0.123.7 which caps starlette at <0.51.0, preventing the fix. fastapi is upgraded to >=0.134.0 solely to unblock the starlette upgrade.

Addresses : https://redhat.atlassian.net/browse/RHOAIENG-64864