### PR TITLE
fix: Update python-dotenv to 1.2.2 to fix CVE-2026-28684

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -30,7 +30,7 @@ ENV VIRTUAL_ENV=/caikit/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN /caikit/.venv/bin/pip install --no-cache-dir \
-    "fastapi>=0.134.0" "starlette>=1.0.1" "aiohttp>=3.13.3,<4.0.0"
+    "fastapi>=0.134.0" "starlette>=1.0.1" "aiohttp>=3.13.3,<4.0.0" "python-dotenv==1.2.2"
 
 RUN groupadd --system caikit --gid 1001 && \
     adduser --system --uid 1001 --gid 0 --groups caikit \


### PR DESCRIPTION
Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED


Verified package got updated ran ods-ci test suite and all tests passed.
```
bash-5.1$ pip show python-dotenv
WARNING: The directory '/caikit/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
Name: python-dotenv
Version: 1.2.2
Summary: Read key-value pairs from a .env file and set them as environment variables
Home-page: 
Author: 
Author-email: Saurabh Kumar <me+github@saurabh-kumar.com>
License: BSD-3-Clause
Location: /caikit/.venv/lib/python3.12/site-packages
Requires: 
Required-by: pydantic-settings```